### PR TITLE
ci: use org reusable workflows (CI + optional deploy)

### DIFF
--- a/.github/workflows/org-ci.yml
+++ b/.github/workflows/org-ci.yml
@@ -1,0 +1,47 @@
+name: CI + Deploy
+on:
+  pull_request:
+    branches: ["**"]
+  push:
+    branches-ignore:
+      - 'ci/failure-*'
+  workflow_dispatch:
+permissions:
+  actions: read
+  contents: write
+  pull-requests: write
+  issues: write
+jobs:
+  ci:
+    name: Reusable CI
+    uses: ds-engageiq/workflow/.github/workflows/reusable-ci.yml@main
+    with:
+      go-enabled: false
+      go-version: '1.22.x'
+      go-workdir: '.'
+      golangci-lint-enabled: true
+      govulncheck-enabled: true
+      node-enabled: false
+      node-autodetect: true
+      migrations-enabled: false
+      migrations-db-type: 'mysql'
+      mysql-image: 'mysql:8'
+      mysql-root-password: 'root'
+      mysql-database: 'testdb'
+      migrations-sql-glob: 'migrations/*.sql'
+      docker-build-enabled: false
+      docker-context: '.'
+      dockerfile: 'Dockerfile'
+      shellcheck-enabled: true
+    secrets: inherit
+  deploy:
+    name: Deploy on CI success
+    needs: ci
+    if: ${{ needs.ci.result == 'success' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    uses: ds-engageiq/workflow/.github/workflows/ultra-safe-deploy-reusable.yml@main
+    with:
+      environment: staging
+      ref: ${{ github.sha }}
+      workdir: .
+      script: deploy.sh
+    secrets: inherit

--- a/.github/workflows/org-ci.yml
+++ b/.github/workflows/org-ci.yml
@@ -19,8 +19,8 @@ jobs:
       go-enabled: false
       go-version: '1.22.x'
       go-workdir: '.'
-      golangci-lint-enabled: true
-      govulncheck-enabled: true
+      golangci-lint-enabled: false
+      govulncheck-enabled: false
       node-enabled: false
       node-autodetect: true
       migrations-enabled: false


### PR DESCRIPTION
Adopt org reusable CI and optional deploy.
- CI: ds-engageiq/workflow@main
- Auto failure PRs on push failures
- Deploy (only if deploy.sh present): ultra-safe-deploy-reusable.yml@main

Adjust toggles (go/node/migrations/docker) as needed.
